### PR TITLE
Proper multi-arch support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM armhf/debian:jessie
+FROM debian:jessie
 
 ENV DEBIAN_FRONTEND="noninteractive"
 
 RUN apt-get update && apt-get install -y apcupsd && apt-get clean
 
-ENTRYPOINT ["/bin/bash"]
+ENTRYPOINT ["/sbin/apcupsd", "-b"]
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ docker run --rm -it -v $PWD/apcupsd.conf:/etc/apcupsd/apcupsd.conf --device=/dev
 Once in the container:
 
 ```
-apcupsd
-# Wait for startup message
 apcaccess
 ```
 


### PR DESCRIPTION
Most, if not all, of the official images support a bunch of different architectures, amd64, armhf, etc. Starting from a base image like this works on both amd64 and armhf.

This PR also starts apcupsd in a container friendly way.